### PR TITLE
Link/2nd level bullet point color change for readability

### DIFF
--- a/dist/dist.css
+++ b/dist/dist.css
@@ -4,7 +4,7 @@
   --editor-bg-color: #202020;
   --border-color: #13131a;
   --ui-text-color: #d8d8d8;
-  --sn-stylekit-info-color: #086DD6;
+  --sn-stylekit-info-color: #4CA3FF;
   --sn-stylekit-info-contrast-color: white;
   --sn-stylekit-neutral-color: #7c7c7c;
   --sn-stylekit-neutral-contrast-color: white;

--- a/src/main.scss
+++ b/src/main.scss
@@ -5,7 +5,7 @@
   --border-color: #13131a;
   --ui-text-color: #d8d8d8;
 
-  --sn-stylekit-info-color: #086DD6;
+  --sn-stylekit-info-color: #4CA3FF;
   --sn-stylekit-info-contrast-color: white;
 
   --sn-stylekit-neutral-color: #7c7c7c;


### PR DESCRIPTION
Changes the link/2nd level bullet point color to a brighter blue to have enough contrast so that it's easier on the eye.

Closes #7.

I couldn't figure out how to change the 1st level bullet point green, please add that as well in this or another PR (that would close #6). My recommendation is #01be79.